### PR TITLE
Add instructions for reproducing/verifying the production firmware images

### DIFF
--- a/FWUPDATE.md
+++ b/FWUPDATE.md
@@ -1,0 +1,63 @@
+# Updating the Firmware on a Blockstream Jade Unit
+
+Blockstream Jade firmware is best updated via a Blockstream Green wallet application - available for Android, iOS, Windows, Mac and Linux.
+
+The firmware can also be updated using a small script provided in this repo, as below.
+
+NOTE: Blockstream Jade units will only run firmware signed by Blockstream, therefore it is not possible to build and flash the firmware on a 'diy' basis.
+The signed firmware must be downloaded from Blockstream servers, and can only be updated using the 'OTA' function of the currently installed firmware.
+
+NOTE: To build and flash firmware for other supported esp32 devices - eg. M5Stack or TTGO T-Display, follow the developers instructions in the main README.md.
+
+
+# Method 1 - Download and Update - One Step
+
+The Jade unit should be switched on, and connected via a good quality USB data cable.
+Run the update script - this will inspect the connected Jade to determine its hardware type/revision, and should then display a list of available firmwares appropriate for the connected device.
+```
+./update_jade_fw.py
+```
+By default the latest stable release is fetched - it is possible to fetch older/previous versions, or indeed beta versions, using the `--release` option.
+NOTE: downgrading to a previous version once a wallet has been setup on the device with a later version is not recommended.
+Firmware deltas are listed before full firmware images - deltas are much smaller and faster to fetch and upload and so are usually preferred.
+
+Select the firmware to fetch.  This should then be downloaded.
+
+When asked whether to save a local copy of the firmware file, answer 'n' as this is unnecessary.
+
+When asked whether to upload this file to the connected Jade unit - answer 'y'.
+
+The update should then commence - confirmation is required on the Jade hardware, and the update should then should proceed to completion.
+The Jade unit should restart and boot the updated firmware.
+
+
+# Method 2 - Download and Update - Two Separate Steps
+
+As above - run the script and select the firmware to fetch.
+```
+./update_jade_fw.py
+```
+
+When asked whether to save a local copy of the firmware file, answer 'y' - a copy of the firmware will be written to the current directory.
+
+When asked whether to upload this file to the connected Jade unit - answer 'n' - the script should exit.
+
+The sha256 hash of the file can then be checked, and is desired the downloaded file can be verified against the source code in this repo (given the appropriate tag/config) - see REPRODUCIBLE.md.
+
+This local file can then be uploaded to the Jade hardware as follows:
+```
+./update_jade_fw.py --fwfile <path to file>
+```
+NOTE: the filename must be unchanged from what was downloaded.
+
+You will be asked whether to upload this file to the connected Jade - answer 'y' and confirm on the Jade unit.
+The update should then run to completion and the Jade should reboot the updated firmware.
+
+
+# Troubleshooting:
+
+The Blockstream Jade unit must be connected and switched on as the script tries to communicate with it - the script will error if no Jade is connected or may hang indefinitely if the Jade is connected but not switched on, or is in the process of some other action (eg. showing an address, signing a message or transaction, etc.)
+
+By default the usb/serial connector tries to use device /dev/ttyUSB0 - this may need to be changed to eg. /dev/ttyACM0 or some other location as appropriate for the o/s platform and driver in use.  In which case, the `--serialport` option can be used.
+
+More verbose logging can be accessed using the `--log` option.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ pip install -r requirements.txt
 ```
 At this point the Jade fw running in the qemu emulator should be available on 'tcp:localhost:2222' from inside and outside the docker container.
 
+# Reproducible Build
+
+See REPRODUCIBLE.md for instructions on locally reproducing the official Blockstream Jade firmware images (minus the Blockstream signature block).
+
 # License
 
 The collection is subject to gpl3 but individual source components can be used under their specific licenses.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Jade Firmware
 
+NOTE: the below instructions are for Jade developers with access to Jade development boards or for those wanting to build and flash their own esp32 consumer devices - eg. M5Stack or TTGO T-Display boards.
+They are not for updating the firmware of an official Blockstream Jade hw unit - these can only be updated in-app, or using the 'update_jade_fw.py' script - see FWUPDATE.md
+
+* DO NOT ATTEMPT THE BELOW WITH BLOCKSTREAM OFFICIAL BLOCKSTREAM JADE HW UNITS
+
 To build you can use the docker image (see Dockerfile) or install the esp-idf toolchain and repo following the commands in this readme.
 
 # Use docker

--- a/REPRODUCIBLE.md
+++ b/REPRODUCIBLE.md
@@ -1,0 +1,148 @@
+# Reproducible Build
+
+The following assumes the jade repo is cloned, checked-out to the appropriate release tag, and all submodules updated.
+
+NOTE: DO NOT TRY TO FLASH OR OTA THESE BUILD ARTIFACTS ONTO A JADE OR ANY OTHER ESP32 HARDWARE.
+
+They contain settings to encrypt the flash and to enable 'secure boot' - this burns 'efuses' on the device - a one-way operation, and may render the device unusable.  
+As the built firmware does not include the Blockstream signature, the fw will not run on an official Blockstream Jade device.
+
+The purpose of these builds is purely to reproduce the build and hence verify the firmware offered by Blockstream is indeed built from the publicly available tagged source code.
+
+1. Create Docker image
+
+Use `Dockerfile` to create a docker image for building the Jade firmware - this builds/installs the required tools from their public repos on a Debian base - the resultant image should be the same as the one used to build the official firmware binaries.
+(NOTE: Because the Dockerfile executes 'apt install' commands, the point versions of some tools may change, so the image may not be completely identical - but these differences should be minor and are not expected to affect the build result in most cases.)
+```
+DOCKER_BUILDKIT=1 docker build -f ./Dockerfile -t jade_builder .
+```
+
+2. Run the container
+```
+docker run -v ${PWD}:/builds/blockstream/jade --name jade_builder -it jade_builder bash
+```
+NOTE: The path where the jade repo is mapped (`/builds/blockstream/jade`) is encoded into the intermediate build files `jade.map` and `jade.elf`, and a hash of the ELF file is included in the final binary - so this path must be correct for the binaries to correctly reflect the Blockstream official build.
+
+All following commands are to be run inside the 'jade_builder' docker container.
+
+3. Prepare the build environment
+```
+. /root/esp/esp-idf/export.sh
+cd /builds/blockstream/jade
+```
+
+* RE-RUN FROM HERE TO BUILD DIFFERENT CONFIGURATIONS
+
+4. Copy the relevant config file
+
+Copy the relevant config file onto `./sdkconfig.defaults`.  The production build configs are in the directory `production`, as follows:
+
+| Jade Hardware Type          | Configuration | sdkconfig.defaults source file                           |
+| --------------------------- | ------------- | -------------------------------------------------------- |
+| Jade 1.0 (true wheel)       | BLE-enabled   | ./production/sdkconfig_jade_prod.defaults                |
+|                             | no-radio      | ./production/sdkconfig_jade_noradio_prod.defaults        |
+| Jade 1.1 (rocker/jog-wheel) | BLE-enabled   | ./production/sdkconfig_jade_v1_1_prod.defaults           |
+|                             | no-radio      | ./production/sdkconfig_jade_v1_1_noradio_prod.defaults   |
+
+eg:
+```
+cp ./production/sdkconfig_jade_prod.defaults sdkconfig.defaults
+rm -f sdkconfig
+```
+NOTE: The `rm -f sdkconfig` step is not necessary on a fresh/clean repo, but always best to ensure this file does not exist and is recreated from the `sdkconfig.defaults` file.  This is vital if the `skconfig.defaults` file is changed (eg. to build another configuration).
+
+5. Build
+```
+idf.py fullclean all
+```
+This makes a fw file `build/jade.bin`.
+
+6. Sign the binary with the 'dev' key
+```
+espsecure.py sign_data --keyfile ./release/scripts/dev_fw_signing_key.pem --version 2 --output ./build/jade_signed.bin ./build/jade.bin
+```
+
+7. Compare signed and unsigned binaries
+
+A diff of `./build/jade_signed.bin` against `./build/jade.bin` should just show extra padding and data suffixed to the binary - this is the signature block.
+(A hex dump can be obtained using `xxd`, which is perhaps easier to diff)
+
+# Download Blockstream Jade Firmware
+
+1. Download the official Blockstream Jade firmware, suppliying the relevant `hw-target` flag:
+
+| Jade Hardware Type          | --hw-target flag    |
+| --------------------------- | ------------------- |
+| Jade 1.0 (true wheel)       | --hw-target jade    |
+| Jade 1.1 (rocker/jog-wheel) | --hw-target jade1.1 |
+
+eg:
+```
+pip install -r ./requirements.txt
+python ./jade_ota.py --skipserial --skipble --write-compressed --download-firmware --release stable --hw-target jade
+```
+Select the full firmware image as appropriate (BLE-enabled or no-radio) - NOTE: ignore the 'deltas' at this time.
+```
+2)  0.1.33 - ble
+```
+
+This should write the compressed firmware image to the build/ directory, eg `./build/0.1.33_ble_1118208_fw.bin`
+
+NOTE: Ensure no Jade is connected, and that `--skipserial --skipble` are definitely present on the command line - otherwise `jade_ota.py` may attempt to upload the firmware onto the connected Jade!
+
+NOTE: this initial step can be skipped if the downloaded firmware is already present, eg. from a prior run of `jade_ota.py` or `update_jade_fw.py`.
+
+2. Uncompress the downloaded firmware
+```
+apt update && apt install pigz
+mv build/0.1.33_ble_1118208_fw.bin build/0.1.33_ble_1118208_fw.bin.gz && pigz -z -d build/0.1.33_ble_1118208_fw.bin.gz
+```
+This should write the uncompressed firmware to the build directory, eg: `./build/0.1.33_ble_1118208_fw.bin`
+
+3. Compare
+
+A diff of the uncompressed downloaded binary against the locally built `./build/jade.bin` should just show extra padding and data suffixed to the binary - this is the Blockstream signature block.
+
+A diff of the uncompressed downloaded binary against `./build/jade_signed.bin` should just show differences in that trailing the signature block.
+(A hex dump can be obtained using `xxd`, which is perhaps easier to diff)
+
+# Delta Firmwares
+
+Since `0.1.33` it has been possible to update Jade firmware using binary deltas.  In this case a 'diff' between the currently running firmware and the desired target firmware is uploaded and applied.  These deltas are much smaller than a complete firmware image.  Verifying these patches is straightforward assuming the relevant full firmware images have been verified as above, as the patch is simply a binary diff between two signed firmware images.
+
+1. Obtain signed/downloaded full firmware images
+
+Take two signed firmware images provided by Blockstream, eg. `0.1.33_ble_1118208_fw.bin` and `0.1.34_ble_1118208_fw.bin`
+NOTE: it may be necessary to pass `--release previous` when downloading the firmware, in order to access older versions.
+
+2. If necessary, verify these images
+
+Verify these firmware images match the tagged source code using the steps described above.
+
+3. Create patches
+
+Create the compressed binary diff patches between the two signed/downloaded firmware images
+```
+mkdir patches
+./tools/mkpatch.py 0.1.33_ble_1118208_fw.bin 0.1.34_ble_1118208_fw.bin patches
+```
+This should create two patches for converting between these firmware images, one for each 'direction'.
+
+NOTE: it may be necessary to compile the `bsdiff` tool:
+```
+gcc -O2 -DBSDIFF_EXECUTABLE -o tools/bsdiff components/esp32_bsdiff/bsdiff.c
+```
+
+4. Download the Blockstream provided patch
+```
+python ./jade_ota.py --skipserial --skipble --write-compressed --download-firmware --release stable --hw-target jade
+```
+Select the relevant delta/patch - eg:
+```
+6)  0.1.34 - ble      FROM  0.1.33 - ble
+```
+
+5. Compare
+
+The dowloaded patch file and the patch created locally ought to be identical.
+This can be verified with `diff`, or better still with `sha256sum` - the hashes of the files should be identical.

--- a/main/process/dashboard.c
+++ b/main/process/dashboard.c
@@ -322,10 +322,10 @@ static void dispatch_message(jade_process_t* process)
         task_function = auth_user_process;
     } else if (IS_METHOD("ota")) {
         // OTA is allowed if either:
-        // a) User has passed PIN screen and has unlocked Jade
+        // a) User has passed PIN screen and has unlocked Jade saved wallet
         // or
         // b) There is no PIN set (ie. no encrypted keys set, eg. new device)
-        if (KEYCHAIN_UNLOCKED_BY_MESSAGE_SOURCE(process) || !keychain_has_pin()) {
+        if ((KEYCHAIN_UNLOCKED_BY_MESSAGE_SOURCE(process) && !keychain_has_temporary()) || !keychain_has_pin()) {
             task_function = ota_process;
         } else {
             // Reject the message as hw locked
@@ -334,10 +334,10 @@ static void dispatch_message(jade_process_t* process)
         }
     } else if (IS_METHOD("ota_delta")) {
         // OTA delta is allowed if either:
-        // a) User has passed PIN screen and has unlocked Jade
+        // a) User has passed PIN screen and has unlocked Jade saved wallet
         // or
         // b) There is no PIN set (ie. no encrypted keys set, eg. new device)
-        if (KEYCHAIN_UNLOCKED_BY_MESSAGE_SOURCE(process) || !keychain_has_pin()) {
+        if ((KEYCHAIN_UNLOCKED_BY_MESSAGE_SOURCE(process) && !keychain_has_temporary()) || !keychain_has_pin()) {
             task_function = ota_delta_process;
         } else {
             // Reject the message as hw locked

--- a/main/process/ota.c
+++ b/main/process/ota.c
@@ -72,6 +72,7 @@ static int uncompressed_stream_writer(void* ctx, uint8_t* uncompressed, size_t t
 void ota_process(void* process_ptr)
 {
     JADE_LOGI("Starting: %u", xPortGetFreeHeapSize());
+
     jade_process_t* process = process_ptr;
     bool uploading = false;
     enum ota_status ota_return_status = ERROR_OTA_SETUP;
@@ -87,6 +88,10 @@ void ota_process(void* process_ptr)
     // We expect a current message to be present
     ASSERT_CURRENT_MESSAGE(process, "ota");
     GET_MSG_PARAMS(process);
+    if (keychain_has_pin()) {
+        ASSERT_KEYCHAIN_UNLOCKED_BY_MESSAGE_SOURCE(process);
+        JADE_ASSERT(!keychain_has_temporary());
+    }
 
     const jade_msg_source_t source = process->ctx.source;
 

--- a/main/process/ota_delta.c
+++ b/main/process/ota_delta.c
@@ -122,6 +122,10 @@ void ota_delta_process(void* process_ptr)
     // We expect a current message to be present
     ASSERT_CURRENT_MESSAGE(process, "ota_delta");
     GET_MSG_PARAMS(process);
+    if (keychain_has_pin()) {
+        ASSERT_KEYCHAIN_UNLOCKED_BY_MESSAGE_SOURCE(process);
+        JADE_ASSERT(!keychain_has_temporary());
+    }
 
     size_t firmwaresize = 0;
     size_t compressedsize = 0;

--- a/update_jade_fw.py
+++ b/update_jade_fw.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import time
+import json
+import logging
+import argparse
+import requests
+
+from jadepy import JadeAPI, JadeError
+from tools import fwtools
+
+FWSERVER_URL_ROOT = 'https://jadefw.blockstream.com/bin'
+FWSERVER_INDEX_FILE = 'index.json'
+
+# Enable jade logging
+jadehandler = logging.StreamHandler()
+logger = logging.getLogger('jade')
+logger.setLevel(logging.DEBUG)
+logger.addHandler(jadehandler)
+device_logger = logging.getLogger('jade-device')
+device_logger.setLevel(logging.DEBUG)
+device_logger.addHandler(jadehandler)
+
+
+# Parse the index file and select firmware to download
+def get_fw_metadata(verinfo, release_data):
+    # Select firmware from list of available
+    def _full_fw_label(fw):
+        return f'{fw["version"]} - {fw["config"]}'
+
+    def _delta_fw_label(fw):
+        return _full_fw_label(fw).ljust(18) + f'FROM  {fw["from_version"]} - {fw["from_config"]}'
+
+    def _delta_appropriate(fw):
+        return fw['from_version'] == verinfo['JADE_VERSION'] and \
+               fw['from_config'].lower() == verinfo['JADE_CONFIG'].lower()
+
+    print(f'Current Jade fw: {verinfo["JADE_VERSION"]} - {verinfo["JADE_CONFIG"].lower()}')
+    print('-')
+
+    i = 0
+    print('Delta patches (faster)')
+    deltas = list(filter(_delta_appropriate, release_data.get('delta', [])))
+    for i, label in enumerate((_delta_fw_label(fw) for fw in deltas), i + 1):  # 1 based index
+        print(f'{i})'.ljust(3), label)
+    print('-')
+
+    print('Full firmware images')
+    fullfws = release_data.get('full', [])
+    for i, label in enumerate((_full_fw_label(fw) for fw in fullfws), i + 1):  # continue numbering
+        print(f'{i})'.ljust(3), label)
+    print('-')
+
+    numdeltas = len(deltas)
+    while True:
+        selectedfw = input('Select firmware: ')
+        if selectedfw.isdigit():
+            selectedfw = int(selectedfw)
+            if selectedfw > 0 and selectedfw <= i:
+                selectedfw -= 1  # zero-based index
+                if selectedfw < numdeltas:
+                    # delta firmware
+                    selectedfw = deltas[selectedfw]
+                else:
+                    selectedfw -= numdeltas
+                    selectedfw = fullfws[selectedfw]
+                return selectedfw
+
+
+# Download compressed firmware file from Firmware Server using 'requests'
+def download_file(verinfo, release):
+    # Workout hw_target subdir
+    hw_target = {'JADE': 'jade', 'JADE_V1.1': 'jade1.1'}.get(verinfo['BOARD_TYPE'])
+    build_type = {'SB': '', 'DEV': 'dev'}.get(verinfo['JADE_FEATURES'])
+    if hw_target is None or build_type is None:
+        logger.error(f'Unsupported hardware: {verinfo["BOARD_TYPE"]} / {verinfo["JADE_FEATURES"]}')
+        return None
+    hw_target += build_type
+
+    # GET the index file from the firmware server which lists the
+    # available firmwares
+    url = f'{FWSERVER_URL_ROOT}/{hw_target}/{FWSERVER_INDEX_FILE}'
+    logger.info(f'Downloading firmware index file {url}')
+    rslt = requests.get(url)
+    assert rslt.status_code == 200, f'Cannot download index file {url}: {rslt.status_code}'
+
+    # Get the filename of the firmware to download
+    release_data = json.loads(rslt.text).get(release)
+    if not release_data:
+        logger.warning(f'No suitable firmware for tag: {release}')
+        return None, None, None
+
+    fwdata = get_fw_metadata(verinfo, release_data)
+    fwname = fwdata['filename']
+
+    # GET the selected firmware from the server
+    url = f'{FWSERVER_URL_ROOT}/{hw_target}/{fwname}'
+    logger.info(f'Downloading firmware {url}')
+    rslt = requests.get(f'{FWSERVER_URL_ROOT}/{hw_target}/{fwname}')
+    assert rslt.status_code == 200, f'Cannot download firmware file {url}: {rslt.status_code}'
+
+    fwcmp = rslt.content
+    logger.info(f'Downloaded {len(fwcmp)} byte firmware')
+
+    # Optionally save the file locally
+    write_file = input('Save local copy of downloaded firmware? [y/N]').strip()
+    if write_file == 'y' or write_file == 'Y':
+        fwtools.write(fwcmp, os.path.basename(fwname))
+
+    # Return
+    return fwdata['fwsize'], fwdata.get('patch_size'), fwcmp
+
+
+# Use a local (previously downloaded) firmware file.
+# Must have the name unchanged from download.
+# Handles full firmwares and also compressed firmware patches.
+def get_local_fwfile(fwfilename):
+    # Load the firmware file
+    assert os.path.exists(fwfilename) and os.path.isfile(
+            fwfilename), f'Compressed firmware file not found: {fwfilename}'
+
+    # Read the fw file
+    fwcmp = fwtools.read(fwfilename)
+
+    # Use fwtools to parse the filename and deduce whether this is
+    # a full firmware file or a firmware delta/patch.
+    fwtype, fwinfo, fwinfo2 = fwtools.parse_compressed_filename(fwfilename)
+    assert (fwtype == fwtools.FWFILE_TYPE_PATCH) == (fwinfo2 is not None)
+
+    return fwinfo.fwsize, fwinfo2.fwsize if fwinfo2 else None, fwcmp
+
+
+# Takes the compressed firmware data to upload, the expected length of the
+# final (uncompressed) firmware, the length of the uncompressed diff/patch
+# (if this is a patch to apply to the current running firmware), and whether
+# to apply the test mnemonic rather than using normal pinserver authentication.
+def ota(jade, verinfo, fwcompressed, fwlength, patchlen=None):
+    logger.info(f'Running OTA on: {verinfo}')
+    chunksize = int(verinfo['JADE_OTA_MAX_CHUNK'])
+    assert chunksize > 0
+
+    if verinfo['JADE_STATE'] not in ['READY', 'UNINIT']:
+        # The network to use is deduced from the version-info
+        print('Please ensure Jade is unlocked')
+        network = 'testnet' if verinfo.get('JADE_NETWORKS') == 'TEST' else 'mainnet'
+        while not jade.auth_user(network, epoch=int(time.time())):
+            print('Please try again')
+
+    start_time = time.time()
+    last_time = start_time
+    last_written = 0
+
+    # Callback to log progress
+    def _log_progress(written, compressed_size):
+        nonlocal last_time
+        nonlocal last_written
+
+        current_time = time.time()
+        secs = current_time - last_time
+        total_secs = current_time - start_time
+        bytes_ = written - last_written
+        last_rate = bytes_ / secs
+        avg_rate = written / total_secs
+        progress = (written / compressed_size) * 100
+        secs_remaining = (compressed_size - written) / avg_rate
+        template = '{0:.2f} b/s - progress {1:.2f}% - {2:.2f} seconds left'
+        print(template.format(last_rate, progress, secs_remaining))
+        print('Written {0}b in {1:.2f}s'.format(written, total_secs))
+
+        last_time = current_time
+        last_written = written
+
+    print('Please approve the firmware update on the Jade device')
+    try:
+        result = jade.ota_update(fwcompressed, fwlength, chunksize,
+                                 patchlen=patchlen, cb=_log_progress)
+        assert result is True
+        print(f'Total OTA time: {time.time() - start_time}s')
+    except JadeError as err:
+        logger.error(f'OTA failed or abandoned: {err}')
+        print('OTA incompelte')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--serialport',
+                        action='store',
+                        dest='serialport',
+                        help='Serial port or device',
+                        default=None)
+
+    srcgrp = parser.add_mutually_exclusive_group()
+    srcgrp.add_argument('--release',
+                        action='store',
+                        dest='release',
+                        choices=['previous', 'stable', 'beta'],
+                        help='Use previous or beta versions, if available.  Defaults to stable.',
+                        default=None)
+
+    srcgrp.add_argument('--fwfile',
+                        action='store',
+                        dest='fwfile',
+                        help='Local (previously downloaded) file to OTA - full or patch',
+                        default=None)
+
+    parser.add_argument('--log',
+                        action='store',
+                        dest='loglevel',
+                        help='Jade logging level',
+                        choices=['DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'],
+                        default='ERROR')
+
+    args = parser.parse_args()
+    jadehandler.setLevel(getattr(logging, args.loglevel))
+    logger.debug(f'args: {args}')
+
+    # Connect to Jade over serial
+    with JadeAPI.create_serial(device=args.serialport) as jade:
+        # Get the version info
+        verinfo = jade.get_version_info()
+
+    # Get the file to OTA
+    if args.fwfile:
+        # Can't check that local file is appropriate for connected hw
+        # OTA should reject/fail if not appropriate.
+        # File must have the name unchanged from download.
+        fwlen, patchlen, fwcmp = get_local_fwfile(args.fwfile)
+    else:
+        # File download should only offer appropriate fw
+        # OTA should reject/fail if not appropriate.
+        release = args.release or 'stable'  # defaults to latest/stable
+        fwlen, patchlen, fwcmp = download_file(verinfo, release)
+
+    if fwcmp is None:
+        print('No firmware available')
+        sys.exit(2)
+
+    print(f'Got fw {"patch" if patchlen else "file"} of length {len(fwcmp)} '
+          f'with expected uncompressed final fw length {fwlen}')
+
+    # OTA file to connected Jade hw
+    upload = input('Upload fw to connected Jade [Y/n]').strip()
+    if upload == 'y' or upload == 'Y' or upload == '':
+        logger.info('Jade OTA over serial')
+        with JadeAPI.create_serial(device=args.serialport) as jade:
+            ota(jade, verinfo, fwcmp, fwlen, patchlen)
+    else:
+        logger.info('Skipping upload')


### PR DESCRIPTION
Instructions to reproduce the official Blockstream Jade firmware builds from this repo.

FYI: if following these instructions for a Jade 1.0 BLE build of tag `0.1.33`, the 'jade.bin' created at step 5. should be:
```
% sha256sum ./build/jade.bin
8d4fce5f5aa1869dd624303329f724b72088ebf7413be72d259804eaa69761ec  ./build/jade.bin
```
This matches what I have created locally, and what was present on the build server before signing/compressing etc.