### PR TITLE
nest loggers in the proper way

### DIFF
--- a/components/assets/gen_assets.py
+++ b/components/assets/gen_assets.py
@@ -4,7 +4,7 @@ import json
 import os
 
 # Enable logging
-logger = logging.getLogger('gen_assets')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 

--- a/jade_auth.py
+++ b/jade_auth.py
@@ -19,11 +19,11 @@ if LOGGING:
     jadehandler = logging.StreamHandler()
     jadehandler.setLevel(logging.INFO)
 
-    logger = logging.getLogger('jade')
+    logger = logging.getLogger('jadepy.jade')
     logger.setLevel(logging.DEBUG)
     logger.addHandler(jadehandler)
 
-    logger = logging.getLogger('jade-device')
+    logger = logging.getLogger('jadepy.jade-device')
     logger.setLevel(logging.DEBUG)
     logger.addHandler(jadehandler)
 

--- a/jade_capture_image_data.py
+++ b/jade_capture_image_data.py
@@ -13,11 +13,11 @@ if LOGGING:
     jadehandler = logging.StreamHandler()
     jadehandler.setLevel(LOGGING)
 
-    logger = logging.getLogger('jade')
+    logger = logging.getLogger('jadepy.jade')
     logger.setLevel(LOGGING)
     logger.addHandler(jadehandler)
 
-    device_logger = logging.getLogger('jade-device')
+    device_logger = logging.getLogger('jadepy.jade-device')
     device_logger.setLevel(LOGGING)
     device_logger.addHandler(jadehandler)
 

--- a/jade_ota.py
+++ b/jade_ota.py
@@ -27,11 +27,11 @@ COMP_FW_DIR = 'build'
 # Enable jade debug logging
 jadehandler = logging.StreamHandler()
 
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.DEBUG)
 logger.addHandler(jadehandler)
 
-device_logger = logging.getLogger('jade-device')
+device_logger = logging.getLogger('jadepy.jade-device')
 device_logger.setLevel(logging.DEBUG)
 device_logger.addHandler(jadehandler)
 

--- a/jadepy/jade.py
+++ b/jadepy/jade.py
@@ -17,8 +17,8 @@ from .jade_serial import JadeSerialImpl
 from .jade_tcp import JadeTCPImpl
 
 # 'jade' logger
-logger = logging.getLogger('jade')
-device_logger = logging.getLogger('jade-device')
+logger = logging.getLogger(__name__)
+device_logger = logging.getLogger(f'{__name__}-device')
 
 # BLE comms backend is optional
 # It relies on the BLE dependencies being available

--- a/jadepy/jade.py
+++ b/jadepy/jade.py
@@ -25,8 +25,8 @@ device_logger = logging.getLogger('jade-device')
 try:
     from .jade_ble import JadeBleImpl
 except ImportError as e:
-    logger.warn(e)
-    logger.warn('BLE scanning/connectivity will not be available')
+    logger.warning(e)
+    logger.warning('BLE scanning/connectivity will not be available')
 
 
 # Default serial connection
@@ -1718,7 +1718,7 @@ class JadeInterface:
         Log any/all outstanding messages/data.
         NOTE: can run indefinitely if data is arriving constantly.
         """
-        logger.warn("Draining interface...")
+        logger.warning("Draining interface...")
         drained = bytearray()
         finished = False
 
@@ -1729,14 +1729,14 @@ class JadeInterface:
 
             if finished or byte_ == b'\n' or len(drained) > 256:
                 try:
-                    device_logger.warn(drained.decode('utf-8'))
+                    device_logger.warning(drained.decode('utf-8'))
                 except Exception as e:
                     # Dump the bytes raw and as hex if decoding as utf-8 failed
-                    device_logger.warn("Raw:")
-                    device_logger.warn(drained)
-                    device_logger.warn("----")
-                    device_logger.warn("Hex dump:")
-                    device_logger.warn(drained.hex())
+                    device_logger.warning("Raw:")
+                    device_logger.warning(drained)
+                    device_logger.warning("----")
+                    device_logger.warning("Hex dump:")
+                    device_logger.warning(drained.hex())
 
                 # Clear and loop to continue collecting
                 drained.clear()
@@ -1870,7 +1870,7 @@ class JadeInterface:
                         response = message['log'].decode("utf-8")
                         log_methods = {
                             'E': device_logger.error,
-                            'W': device_logger.warn,
+                            'W': device_logger.warning,
                             'I': device_logger.info,
                             'D': device_logger.debug,
                             'V': device_logger.debug,

--- a/jadepy/jade_ble.py
+++ b/jadepy/jade_ble.py
@@ -115,9 +115,9 @@ class JadeBleImpl:
                 connected = client.is_connected
                 logger.info('Connected: {}'.format(connected))
             except Exception as e:
-                logger.warn("BLE connection exception: '{}'".format(e))
+                logger.warning("BLE connection exception: '{}'".format(e))
                 if not attempts_remaining:
-                    logger.warn("Exhausted retries - BLE connection failed")
+                    logger.warning("Exhausted retries - BLE connection failed")
                     raise
 
         # Peruse services and characteristics
@@ -178,7 +178,7 @@ class JadeBleImpl:
         except Exception as err:
             # Sometimes get an exception when testing connection
             # if the client has already internally disconnected ...
-            logger.warn("Exception when disconnecting ble: {}".format(err))
+            logger.warning("Exception when disconnecting ble: {}".format(err))
 
         # Set the client to None in any case - that will cause the receive
         # generator to terminate and not wait forever for data.
@@ -217,7 +217,7 @@ class JadeBleImpl:
         try:
             await self.write_task
         except asyncio.CancelledError:
-            logger.warn("write() task cancelled having written "
+            logger.warning("write() task cancelled having written "
                         "{} of {} bytes".format(written, towrite))
         finally:
             self.write_task = None

--- a/jadepy/jade_ble.py
+++ b/jadepy/jade_ble.py
@@ -8,7 +8,7 @@ import bleak
 
 from .jade_error import JadeError
 
-logger = logging.getLogger('jade.ble')
+logger = logging.getLogger(__name__)
 
 
 #

--- a/jadepy/jade_serial.py
+++ b/jadepy/jade_serial.py
@@ -31,7 +31,7 @@ class JadeSerialImpl:
                 jades.append(devinfo.device)
 
         if len(jades) > 1:
-            logger.warn(f'Multiple potential jade devices detected: {jades}')
+            logger.warning(f'Multiple potential jade devices detected: {jades}')
 
         return jades[0] if jades else None
 

--- a/jadepy/jade_serial.py
+++ b/jadepy/jade_serial.py
@@ -3,7 +3,7 @@ import logging
 
 from serial.tools import list_ports
 
-logger = logging.getLogger('jade.serial')
+logger = logging.getLogger(__name__)
 
 
 #

--- a/jadepy/jade_tcp.py
+++ b/jadepy/jade_tcp.py
@@ -2,7 +2,7 @@ import socket
 import logging
 
 
-logger = logging.getLogger('jade.tcp')
+logger = logging.getLogger(__name__)
 
 
 #

--- a/set_jade_pinserver.py
+++ b/set_jade_pinserver.py
@@ -9,11 +9,11 @@ from jadepy import JadeAPI
 # Enable jade logging
 jadehandler = logging.StreamHandler()
 
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.INFO)
 logger.addHandler(jadehandler)
 
-device_logger = logging.getLogger('jade-device')
+device_logger = logging.getLogger('jadepy.jade-device')
 device_logger.setLevel(logging.INFO)
 device_logger.addHandler(jadehandler)
 

--- a/test_jade.py
+++ b/test_jade.py
@@ -20,11 +20,11 @@ from jadepy.jade import JadeAPI, JadeError
 # Enable jade logging
 jadehandler = logging.StreamHandler()
 
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.DEBUG)
 logger.addHandler(jadehandler)
 
-device_logger = logging.getLogger('jade-device')
+device_logger = logging.getLogger('jadepy.jade-device')
 device_logger.setLevel(logging.DEBUG)
 device_logger.addHandler(jadehandler)
 

--- a/test_jade.py
+++ b/test_jade.py
@@ -2367,13 +2367,13 @@ def test_sign_liquid_tx(jadeapi, has_psram, has_ble, pattern):
         if not has_psram:
             # Skip any liquid txns too large for reduced message buffer on no-psram devices
             if len(inputdata['txn']) > (15 * 1024):  # esitimate 1k for rest of message fields
-                logger.warn("Skipping test case - tx too large for non-psram device configuration")
+                logger.warning("Skipping test case - tx too large for non-psram device configuration")
                 continue
 
             # Skip any rangeproof tests which cannot be handled by ble-enabled no-psram devices
             if has_ble and \
                any(tcs and 'value_blind_proof' in tcs for tcs in inputdata['trusted_commitments']):
-                logger.warn("Skipping test case - value_blind_proof too large for non-psram device")
+                logger.warning("Skipping test case - value_blind_proof too large for non-psram device")
                 continue
 
         rslt = jadeapi.sign_liquid_tx(inputdata['network'],

--- a/tools/fwprep.py
+++ b/tools/fwprep.py
@@ -8,7 +8,7 @@ import os
 import fwtools
 
 # Enable logging
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.INFO)
 
 

--- a/tools/fwtools.py
+++ b/tools/fwtools.py
@@ -10,7 +10,7 @@ FWFILE_TYPE_FULL = 'fw.bin'
 FWFILE_TYPE_HASH = 'fw.bin.hash'
 FWFILE_TYPE_PATCH = 'patch.bin'
 
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 
 
 # Prefix a directory to an existing filename/path

--- a/tools/mkindex.py
+++ b/tools/mkindex.py
@@ -9,7 +9,7 @@ import os
 import fwtools
 
 # Enable logging
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.INFO)
 
 INDEX_FILENAME = 'index.json'

--- a/tools/mkpatch.py
+++ b/tools/mkpatch.py
@@ -8,7 +8,7 @@ import os
 import fwtools
 
 # Enable logging
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.INFO)
 
 

--- a/update_jade_fw.py
+++ b/update_jade_fw.py
@@ -16,10 +16,10 @@ FWSERVER_INDEX_FILE = 'index.json'
 
 # Enable jade logging
 jadehandler = logging.StreamHandler()
-logger = logging.getLogger('jade')
+logger = logging.getLogger('jadepy.jade')
 logger.setLevel(logging.DEBUG)
 logger.addHandler(jadehandler)
-device_logger = logging.getLogger('jade-device')
+device_logger = logging.getLogger('jadepy.jade-device')
 device_logger.setLevel(logging.DEBUG)
 device_logger.addHandler(jadehandler)
 


### PR DESCRIPTION
This also allows proper logger managing when jadepy is imported elsewhere (e.g. HWI)

See also https://github.com/bitcoin-core/HWI/pull/697