### PR TITLE
feat: Add pin-entry screen for entering account index number

### DIFF
--- a/main/qrmode.c
+++ b/main/qrmode.c
@@ -294,24 +294,33 @@ static bool handle_xpub_options(uint32_t* qr_flags)
                 }
                 update_menu_item(wallet_item, "Wallet", xpub_wallettype_desc_from_flags(*qr_flags));
             } else if (ev_id == BTN_XPUB_OPTIONS_ACCOUNT) {
-                gui_set_current_activity(act_account);
+                pin_insert_t pin_insert = { .initial_state = ZERO, .pin_digits_shown = true };
+                make_pin_insert_activity(&pin_insert, "Account Index", "Enter index:");
+                JADE_ASSERT(pin_insert.activity);
+
                 while (true) {
-                    rc = snprintf(buf, sizeof(buf), "%u", account_index);
-                    JADE_ASSERT(rc > 0 && rc < sizeof(buf));
-                    gui_update_text(account_textbox, buf);
-                    if (gui_activity_wait_event(act_account, GUI_EVENT, ESP_EVENT_ANY_ID, NULL, &ev_id, NULL, 0)) {
-                        if (ev_id == GUI_WHEEL_LEFT_EVENT) {
-                            // Avoid unsigned wrapping below zero
-                            account_index = (account_index + ACCOUNT_INDEX_MAX - 1) % ACCOUNT_INDEX_MAX;
-                        } else if (ev_id == GUI_WHEEL_RIGHT_EVENT) {
-                            account_index = (account_index + 1) % ACCOUNT_INDEX_MAX;
-                        } else if (ev_id == gui_get_click_event()) {
-                            // Done
-                            break;
-                        }
+                    gui_set_current_activity(pin_insert.activity);
+                    if (!run_pin_entry_loop(&pin_insert)) {
+                        // User abandoned index entry
+                        break;
+                    }
+
+                    // Get entered digits as single numeric value
+                    uint32_t new_account_index = get_pin_as_number(&pin_insert);
+                    if (new_account_index < ACCOUNT_INDEX_MAX) {
+                        account_index = new_account_index;
+                        
+                        // Update the display
+                        const int ret = snprintf(buf, sizeof(buf), "%u", account_index);
+                        JADE_ASSERT(ret > 0 && ret < sizeof(buf));
+                        update_menu_item(account_item, "Account Index", buf);
+                        
+                        break;
+                    } else {
+                        const char* message[] = { "Invalid index", "Please try again" };
+                        await_message_activity(message, 2);
                     }
                 }
-                update_menu_item(account_item, "Account Index", buf);
             } else if (ev_id == BTN_XPUB_OPTIONS_HELP) {
                 await_qr_help_activity("blkstrm.com/xpub");
             } else if (ev_id == BTN_XPUB_OPTIONS_EXIT) {
@@ -516,15 +525,10 @@ static bool handle_address_options(const bool show_account, uint16_t* account_in
     gui_activity_t* const act_options = make_search_address_options_activity(show_account, &account_item, &change_item);
     JADE_ASSERT(!account_item == !show_account);
 
-    gui_activity_t* act_account = NULL;
-    gui_view_node_t* account_textbox = NULL;
     if (account_item) {
         const int ret = snprintf(buf, sizeof(buf), "%u", *account_index);
         JADE_ASSERT(ret > 0 && ret < sizeof(buf));
         update_menu_item(account_item, "Account Index", buf);
-
-        act_account = make_carousel_activity("Account Index", NULL, &account_textbox);
-        gui_update_text(account_textbox, buf);
     }
     update_menu_item(change_item, "Change", *is_change ? "Yes" : "No");
 
@@ -535,31 +539,40 @@ static bool handle_address_options(const bool show_account, uint16_t* account_in
         gui_set_current_activity(act_options);
         if (gui_activity_wait_event(act_options, GUI_BUTTON_EVENT, ESP_EVENT_ANY_ID, NULL, &ev_id, NULL, 0)) {
 
-            if (ev_id == BTN_SCAN_ADDRESS_OPTIONS_ACCOUNT) {
-                gui_set_current_activity(act_account);
+            if (ev_id == BTN_SCAN_ADDRESS_OPTIONS_ACCOUNT && show_account) {
+                pin_insert_t pin_insert = { .initial_state = ZERO, .pin_digits_shown = true };
+                make_pin_insert_activity(&pin_insert, "Account Index", "Enter index:");
+                JADE_ASSERT(pin_insert.activity);
+
                 while (true) {
-                    const int ret = snprintf(buf, sizeof(buf), "%u", *account_index);
-                    JADE_ASSERT(ret > 0 && ret < sizeof(buf));
-                    gui_update_text(account_textbox, buf);
-                    if (gui_activity_wait_event(act_account, GUI_EVENT, ESP_EVENT_ANY_ID, NULL, &ev_id, NULL, 0)) {
-                        if (ev_id == GUI_WHEEL_LEFT_EVENT) {
-                            // Avoid unsigned wrapping below zero
-                            *account_index = (*account_index + ACCOUNT_INDEX_MAX - 1) % ACCOUNT_INDEX_MAX;
-                        } else if (ev_id == GUI_WHEEL_RIGHT_EVENT) {
-                            *account_index = (*account_index + 1) % ACCOUNT_INDEX_MAX;
-                        } else if (ev_id == gui_get_click_event()) {
-                            // Done
-                            break;
-                        }
+                    gui_set_current_activity(pin_insert.activity);
+                    if (!run_pin_entry_loop(&pin_insert)) {
+                        // User abandoned index entry
+                        break;
+                    }
+
+                    // Get entered digits as single numeric value
+                    uint32_t new_account_index = get_pin_as_number(&pin_insert);
+                    if (new_account_index < ACCOUNT_INDEX_MAX) {
+                        *account_index = new_account_index;
+                        
+                        // Update the display
+                        const int ret = snprintf(buf, sizeof(buf), "%u", *account_index);
+                        JADE_ASSERT(ret > 0 && ret < sizeof(buf));
+                        update_menu_item(account_item, "Account Index", buf);
+                        
+                        break;
+                    } else {
+                        const char* message[] = { "Invalid index", "Please try again" };
+                        await_message_activity(message, 2);
                     }
                 }
-                update_menu_item(account_item, "Account Index", buf);
             } else if (ev_id == BTN_SCAN_ADDRESS_OPTIONS_CHANGE) {
                 // Simple toggle
                 *is_change = !*is_change;
                 update_menu_item(change_item, "Change", *is_change ? "Yes" : "No");
             } else if (ev_id == BTN_SCAN_ADDRESS_OPTIONS_EXIT) {
-                // Exit optins screen
+                // Exit options screen
                 break;
             }
         }
@@ -568,7 +581,6 @@ static bool handle_address_options(const bool show_account, uint16_t* account_in
     // Return value indicates whether options were changed
     return *is_change != initial_change || *account_index != initial_account;
 }
-
 // Verify an address string by brute-forcing
 static bool verify_address(const address_data_t* const addr_data)
 {


### PR DESCRIPTION
Improves user experience for entering account index numbers by using a pin-entry screen instead of a scrolling carousel. 
![IMG_7761](https://github.com/user-attachments/assets/6e36fbc0-d803-4fc0-8ef9-cb293bfe6594)
![IMG_7762](https://github.com/user-attachments/assets/cd03f2bf-e035-4b2b-a9de-0048ae087b7b)
![IMG_7763](https://github.com/user-attachments/assets/b26720ed-485a-4d89-b893-351295570b7a)

Current Implementation:
- Uses a circular carousel for selecting account indexes
- Limited efficiency when accessing higher account numbers

Proposed Enhancement:
- Implements a numeric keypad interface
- Allows direct input of account index numbers
- Provides a more intuitive and faster method for entering higher account indexes
