### PR TITLE
Added Functionality for Exporting BIP85 Mnemonic as QR Code

### DIFF
--- a/main/process/mnemonic.c
+++ b/main/process/mnemonic.c
@@ -55,6 +55,7 @@ gui_activity_t* make_calculate_final_word_activity(void);
 gui_activity_t* make_confirm_passphrase_activity(const char* passphrase, gui_view_node_t** textbox);
 
 gui_activity_t* make_export_qr_overview_activity(const Icon* icon, bool initial);
+gui_activity_t* make_bip85_qr_overview_activity(const Icon* icon, bool initial);
 gui_activity_t* make_export_qr_fragment_activity(
     const Icon* icon, gui_view_node_t** icon_node, gui_view_node_t** label_node);
 
@@ -1455,58 +1456,6 @@ cleanup:
     SENSITIVE_POP(mnemonic);
 }
 
-static void mnemonic_export_bip85_qr(const char* mnemonic)
-{
-    JADE_ASSERT(mnemonic);
-
-    // CompactSeedQR is simply the mnemonic entropy
-    // Only 12 or 24 word mnemonics are supported (ie. 128 & 256 bit entropy)
-    size_t entropy_len = 0;
-    uint8_t entropy[BIP32_ENTROPY_LEN_256]; // Sufficient for 12 and 24 words
-    JADE_WALLY_VERIFY(bip39_mnemonic_to_bytes(NULL, mnemonic, entropy, sizeof(entropy), &entropy_len));
-    JADE_ASSERT(entropy_len == BIP32_ENTROPY_LEN_128 || entropy_len == BIP32_ENTROPY_LEN_256);
-
-    // Convert the entropy into a small (v1 or v2) qr-code
-    QRCode qrcode;
-    const uint8_t qrcode_version = entropy_len == BIP32_ENTROPY_LEN_128 ? 1 : 2;
-    uint8_t qrbuffer[96]; // underlying qrcode data/work area - opaque
-    JADE_ASSERT(sizeof(qrbuffer) > qrcode_getBufferSize(qrcode_version));
-    const int qret = qrcode_initBytes(&qrcode, qrbuffer, qrcode_version, ECC_LOW, entropy, entropy_len);
-    JADE_ASSERT(qret == 0);
-
-#if CONFIG_DISPLAY_WIDTH >= 480 && CONFIG_DISPLAY_HEIGHT >= 220
-    const uint8_t overview_scale = qrcode_version == 1 ? 9 : 8;
-#elif CONFIG_DISPLAY_WIDTH >= 320 && CONFIG_DISPLAY_HEIGHT >= 170
-    const uint8_t overview_scale = qrcode_version == 1 ? 7 : 6;
-#else
-    const uint8_t overview_scale = qrcode_version == 1 ? 5 : 4;
-#endif
-
-    // Make qr code icon as an overview image
-    Icon qr_overview;
-    qrcode_toIcon(&qrcode, &qr_overview, overview_scale);
-
-    // Show the overview QR
-    gui_activity_t* const act_overview_qr = make_export_qr_overview_activity(&qr_overview, true);
-    gui_set_current_activity(act_overview_qr);
-
-    // Wait for user input
-    int32_t ev_id;
-    while (true) {
-        if (gui_activity_wait_event(act_overview_qr, GUI_BUTTON_EVENT, ESP_EVENT_ANY_ID, NULL, &ev_id, NULL, 0)) {
-            if (ev_id == BTN_QR_EXPORT_DONE || ev_id == BTN_QR_EXPORT_PREV) {
-                // We are done viewing the qr or user wants to go back
-                break;
-            }
-            // Ignore other button events
-        }
-    }
-
-    // Clean up
-    qrcode_freeIcon(&qr_overview);
-    gui_set_current_activity(NULL);
-}
-
 // Function to calculate a bip85 bip39 mnemonic phrase
 // Caller must free with 'wally_free_string()
 // NOTE: only the English wordlist is supported.
@@ -1526,6 +1475,73 @@ void get_bip85_mnemonic(const uint32_t nwords, const uint32_t index, char** new_
     JADE_WALLY_VERIFY(bip39_mnemonic_from_bytes(NULL, entropy, entropy_len, new_mnemonic));
     JADE_ASSERT(new_mnemonic);
     SENSITIVE_POP(entropy);
+}
+
+
+// Export a BIP85-derived mnemonic as a QR code overview
+// Returns true if completed/skipped, false if backed out
+static bool mnemonic_export_qr_bip85(const char* mnemonic) 
+{
+    JADE_ASSERT(mnemonic);
+
+    // Ask user if they want to view the QR
+    const char* question[] = { "View BIP85", "CompactSeedQR" };
+    if (!await_skipyes_activity(NULL, question, 2, true, "blkstrm.com/bip85")) {
+        return true;
+    }
+
+    // Convert mnemonic to entropy bytes
+    size_t entropy_len = 0;
+    uint8_t entropy[BIP32_ENTROPY_LEN_256]; // Sufficient for 12 and 24 words
+    JADE_WALLY_VERIFY(bip39_mnemonic_to_bytes(NULL, mnemonic, entropy, sizeof(entropy), &entropy_len));
+    JADE_ASSERT(entropy_len == BIP32_ENTROPY_LEN_128 || entropy_len == BIP32_ENTROPY_LEN_256);
+
+    // Create QR code from entropy
+    QRCode qrcode;
+    const uint8_t qrcode_version = entropy_len == BIP32_ENTROPY_LEN_128 ? 1 : 2;
+    uint8_t qrbuffer[96];
+    JADE_ASSERT(sizeof(qrbuffer) > qrcode_getBufferSize(qrcode_version));
+    const int qret = qrcode_initBytes(&qrcode, qrbuffer, qrcode_version, ECC_LOW, entropy, entropy_len);
+    JADE_ASSERT(qret == 0);
+
+    // Select scale based on display size
+#if CONFIG_DISPLAY_WIDTH >= 480 && CONFIG_DISPLAY_HEIGHT >= 220
+    const uint8_t overview_scale = qrcode_version == 1 ? 9 : 8;
+#elif CONFIG_DISPLAY_WIDTH >= 320 && CONFIG_DISPLAY_HEIGHT >= 170
+    const uint8_t overview_scale = qrcode_version == 1 ? 7 : 6;
+#else
+    const uint8_t overview_scale = qrcode_version == 1 ? 5 : 4;
+#endif
+
+    // Create overview QR icon
+    Icon qr_overview;
+    qrcode_toIcon(&qrcode, &qr_overview, overview_scale);
+
+    // Show the QR overview and wait for user interaction
+    bool retval = true;
+    gui_activity_t* const act_overview_qr = make_bip85_qr_overview_activity(&qr_overview, true);
+    gui_set_current_activity_ex(act_overview_qr, true);
+
+    int32_t ev_id;
+    while (true) {
+    if (gui_activity_wait_event(act_overview_qr, GUI_BUTTON_EVENT, ESP_EVENT_ANY_ID, NULL, &ev_id, NULL, 0)) {
+        switch (ev_id) {            
+        case BTN_MNEMONIC_EXIT:  // Use the same exit button as display_confirm_mnemonic
+            // User wants to exit/abandon
+            retval = false;
+            goto cleanup;
+            
+        default:
+            // Ignore other buttons
+            continue;
+        }
+    }
+}
+
+
+cleanup:
+    qrcode_freeIcon(&qr_overview);
+    return retval;
 }
 
 // Offer the user the option to generate a bip39 recovery phrase using entropy
@@ -1611,11 +1627,8 @@ void handle_bip85_mnemonic()
     JADE_ASSERT(mnemonic_len < MNEMONIC_BUFLEN);
     SENSITIVE_PUSH(new_mnemonic, mnemonic_len);
 
-   // Display mnemonic as QR code
-    mnemonic_export_bip85_qr(new_mnemonic);
-    // Note: We ignore the return value of mnemonic_export_qr and proceed regardless
-
-    // Proceed with displaying and confirming mnemonic phrase
+    mnemonic_export_qr_bip85(new_mnemonic);
+    // Display and confirm mnemonic phrase
     if (display_confirm_mnemonic(nwords, new_mnemonic, mnemonic_len)) {
         const char* message[] = { "Recovery Phrase", "Confirmed" };
         await_message_activity(message, 2);

--- a/main/ui/mnemonic.c
+++ b/main/ui/mnemonic.c
@@ -406,6 +406,51 @@ gui_activity_t* make_confirm_passphrase_activity(const char* passphrase, gui_vie
     return act;
 }
 
+gui_activity_t* make_bip85_qr_overview_activity(const Icon* icon, const bool initial)
+{
+    JADE_ASSERT(icon);
+
+    gui_activity_t* const act = gui_make_activity();
+
+    gui_view_node_t* hsplit;
+    gui_make_hsplit(&hsplit, GUI_SPLIT_RELATIVE, 2, 45, 55);
+    gui_set_parent(hsplit, act->root_node);
+
+    // lhs - text
+    gui_view_node_t* vsplit;
+    gui_make_vsplit(&vsplit, GUI_SPLIT_RELATIVE, 4, 20, 30, 25, 25);
+    gui_set_parent(vsplit, hsplit);
+
+    // rhs - icon
+    gui_view_node_t* icon_bg;
+    gui_make_fill(&icon_bg, TFT_DARKGREY);
+    gui_set_parent(icon_bg, hsplit);
+
+    gui_view_node_t* node;
+    gui_make_icon(&node, icon, TFT_BLACK, &TFT_LIGHTGREY);
+    gui_set_align(node, GUI_ALIGN_CENTER, GUI_ALIGN_MIDDLE);
+    gui_set_parent(node, icon_bg);
+
+    // First row, header with back/next buttons
+    btn_data_t hdrbtns[] = { 
+        { .txt = "=", .font = JADE_SYMBOLS_16x16_FONT, .ev_id = BTN_MNEMONIC_EXIT, .borders = GUI_BORDER_ALL }
+        // { .txt = NULL, .font = GUI_DEFAULT_FONT, .ev_id = GUI_BUTTON_EVENT_NONE }, // spacer
+        // { .txt = ">", .font = JADE_SYMBOLS_16x16_FONT, .ev_id = BTN_QR_EXPORT_NEXT, .borders = GUI_BORDER_ALL }
+    };
+
+    add_buttons(vsplit, UI_ROW, hdrbtns, 1);
+
+    // Message
+    gui_make_text(&node, "BIP85", TFT_WHITE);
+    gui_set_parent(node, vsplit);
+    gui_set_align(node, GUI_ALIGN_CENTER, GUI_ALIGN_MIDDLE);
+
+    // Select next button by default
+    gui_set_activity_initial_selection(act, hdrbtns[0].btn);
+
+    return act;
+}
+
 gui_activity_t* make_export_qr_overview_activity(const Icon* icon, const bool initial)
 {
     JADE_ASSERT(icon);


### PR DESCRIPTION
For the T Display S3, the screen size is sufficient for users to view the BIP85 QR code and scan it using another device, such as the original Jade. This eliminates the need for manually typing the BIP85 mnemonic.

However, I encountered an issue: the display_confirm_mnemonic function cannot handle the "go back" action properly and causes the interface to freeze.