### PR TITLE
Fix camera OV3660 error

### DIFF
--- a/main/camera.c
+++ b/main/camera.c
@@ -306,6 +306,17 @@ static void jade_camera_init(void)
             JADE_LOGE("Failed to set camera hmirror/vflip, returned: %d/%d", hret, vret);
         }
     }
+
+    // OV3660 needs a vertical flip for the ESP32 Wrover Cam
+    else if (camera_info->model == CAMERA_OV3660) {
+        JADE_ASSERT(camera_sensor->set_vflip);
+        const int vret = camera_sensor->set_vflip(camera_sensor, 1);
+        if (vret) {
+            JADE_LOGE("Failed to set camera vflip, returned: %d", vret);
+        }
+    }
+
+
     // OV5640 needs vertical flip for T-Display S3 PRO
     else if (camera_info->model == CAMERA_OV5640) {
         JADE_ASSERT(camera_sensor->set_vflip);


### PR DESCRIPTION
This fixes the issues that occurred when attempting to read a QR code using the OV3660 camera.