### PR TITLE
Fix release date for version 1.0.38 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.38] - 2025-13-26
+## [1.0.38] - 2025-11-26
 
 Note: This release contains important security updates; All users should
 upgrade as soon as possible. The developers would like to thank


### PR DESCRIPTION
Correct the release date for version 1.0.38. We don't want people waiting till Decembruary for the update.