### PR TITLE
Fix: Navigation Inversion on TTGO T-Display PIN Screen

### DIFF
--- a/main/ui/pin.c
+++ b/main/ui/pin.c
@@ -11,6 +11,15 @@ static const char PIN_CHARS[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '
 static const uint32_t NUM_PIN_CHARS = sizeof(PIN_CHARS) / sizeof(PIN_CHARS[0]);
 static const uint32_t NUM_PIN_VALUES = NUM_PIN_CHARS - 1; // ie. not including backspace
 
+static inline bool pin_entry_invert_navigation(void)
+{
+#if defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAYS3)
+    return true;
+#else
+    return false;
+#endif
+}
+
 static inline char get_pin_value(size_t index)
 {
     JADE_ASSERT(index < NUM_PIN_CHARS);
@@ -190,12 +199,24 @@ bool run_pin_entry_loop(pin_insert_t* pin_insert)
     JADE_ASSERT(pin_insert);
     JADE_ASSERT(pin_insert->activity);
 
+    // TTGO boards need to locally invert navigation so PIN entry matches the rest of the UI.
+    const bool invert_navigation = pin_entry_invert_navigation();
+
     int32_t ev_id;
     while (true) {
         // wait for a GUI event
         gui_activity_wait_event(pin_insert->activity, GUI_EVENT, ESP_EVENT_ANY_ID, NULL, &ev_id, NULL, 0);
 
-        switch (ev_id) {
+        int32_t handled_event = ev_id;
+        if (invert_navigation) {
+            if (handled_event == GUI_WHEEL_LEFT_EVENT) {
+                handled_event = GUI_WHEEL_RIGHT_EVENT;
+            } else if (handled_event == GUI_WHEEL_RIGHT_EVENT) {
+                handled_event = GUI_WHEEL_LEFT_EVENT;
+            }
+        }
+
+        switch (handled_event) {
         case GUI_WHEEL_LEFT_EVENT:
             pin_insert->current_selected_value
                 = (pin_insert->current_selected_value + NUM_PIN_CHARS - 1) % NUM_PIN_CHARS;


### PR DESCRIPTION
## Context

On **TTGO T-Display / T-Display S3** builds, the **PIN entry (unlock) screen** had its navigation **reversed compared to the rest of the UI**. Buttons that behave consistently elsewhere (**A = Up**, **B = Down**) ended up behaving the opposite way on the PIN screen, which:

- breaks muscle memory right at the unlock step,
- increases PIN entry mistakes / frustration,
- and makes the UX feel inconsistent/buggy.

The issue was isolated to how the PIN loop interprets **wheel navigation events**, so the fix is intentionally **local to the PIN screen**, without changing global navigation behavior or affecting the **A+B click** action.

## Changes
- Added `pin_entry_invert_navigation()` in `main/ui/pin.c:14` so TTGO T-Display / T-Display S3 builds flag that the PIN screen must swap its UP/DOWN behavior locally.
- Updated `run_pin_entry_loop()` (`main/ui/pin.c:203`) to flip only the `GUI_WHEEL_LEFT/RIGHT` events when that flag is set, keeping the A+B click and all other screens untouched.

## Testing
- `idf.py build flash monitor` on TTGO T-Display: PIN entry navigation now matches the rest of the UI (A=Up, B=Down).
