### PR TITLE
fix: Verify Secure Boot signature before marking OTA successful

### DIFF
--- a/main/process/ota_util.c
+++ b/main/process/ota_util.c
@@ -10,6 +10,7 @@
 
 #include <ctype.h>
 #include <esp_efuse.h>
+#include <esp_image_format.h>
 #include <sodium/utils.h>
 #include <string.h>
 
@@ -346,6 +347,20 @@ void ota_finalize(jade_process_t* process, jade_ota_ctx_t* joctx, const bool is_
         joctx->ota_return_status = OTA_ERR_FINISH;
         goto error;
     }
+
+#ifdef CONFIG_SECURE_BOOT
+    esp_partition_pos_t update_pos = {
+        .offset = joctx->update_partition->address,
+        .size = joctx->update_partition->size
+    };
+    esp_image_metadata_t metadata;
+    err = esp_image_verify(ESP_IMAGE_VERIFY, &update_pos, &metadata);
+    if (err != ESP_OK) {
+        JADE_LOGE("esp_image_verify() returned %d - likely missing Secure Boot signature", err);
+        joctx->ota_return_status = OTA_ERR_INVALIDFW;
+        goto error;
+    }
+#endif
 
     err = esp_ota_set_boot_partition(joctx->update_partition);
     if (err != ESP_OK) {


### PR DESCRIPTION
## Description
This PR fixes a UX issue where the OTA update process reports "Upgrade successful!" when a user attempts to flash an unsigned firmware binary (e.g., a beta or DIY build) onto production hardware, only for the bootloader to silently reject it and roll back upon reboot.

## The Problem
Currently, `ota_user_validate` and `esp_ota_end` verify the file hash and basic structure, but they do not explicitly check the Secure Boot signature block during the USB OTA process. If an unsigned `.bin` is uploaded to a unit with `CONFIG_SECURE_BOOT=y`, the UI claims success, but the hardware's bootloader rejects the missing signature on the next boot, causing a silent fallback to the previous slot. This leads to user confusion.

## The Solution
In `main/process/ota_util.c`, this PR introduces a call to `esp_image_verify()` within `ota_finalize` (just before `esp_ota_set_boot_partition()` is called). 

If `CONFIG_SECURE_BOOT` is enabled, this ensures the written partition is fully validated—including the presence of a valid Secure Boot signature—before the UI reports success. If the signature is missing, it immediately throws an "Invalid Firmware" error to the user, preventing the silent rollback loop.
