### PR TITLE
Fix M5StickC Plus 2 PIN navigation

### DIFF
--- a/main/ui/digit_entry.c
+++ b/main/ui/digit_entry.c
@@ -12,8 +12,9 @@ static const char ENTRY_CHARS[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8',
 
 static inline bool entry_invert_navigation(void)
 {
-#if defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAYS3)
-    // TTGO boards need to locally invert navigation so number entry matches the rest of the UI.
+#if defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAYS3) \
+    || defined(CONFIG_BOARD_TYPE_M5_STICKC_PLUS_2)
+    // These boards need to locally invert navigation so number entry matches the rest of the UI.
     return true;
 #else
     return false;


### PR DESCRIPTION
## Summary

- include M5StickC Plus 2 in the local digit-entry navigation inversion
- make the physical buttons match the on-screen up/down arrows

## Context

M5StickC Plus 2 has the same reversed navigation behavior on the PIN/number-entry screen that was previously addressed for TTGO boards after #269. The board was missing from the condition in `entry_invert_navigation()`.

Fixes #297.

## Testing

- verified on physical M5StickC Plus 2 hardware
- built the M5StickC Plus 2 firmware successfully with `ninja -C build`
