### PR TITLE
Add M5StickC Plus2 backlight brightness control

### DIFF
--- a/main/display_hw.c
+++ b/main/display_hw.c
@@ -87,7 +87,7 @@ static void esp_lcd_init(void* _ignored)
     esp_lcd_panel_io_handle_t io_handle = NULL;
 
 #if CONFIG_DISPLAY_PIN_BL != -1 && !defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2)                                           \
-    && !defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)
+    && !defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY) && !defined(CONFIG_BOARD_TYPE_M5_STICKC_PLUS_2)
     gpio_config_t bk_gpio_config = { .mode = GPIO_MODE_OUTPUT, .pin_bit_mask = 1ULL << CONFIG_DISPLAY_PIN_BL };
     ESP_ERROR_CHECK(gpio_config(&bk_gpio_config));
     ESP_ERROR_CHECK(gpio_set_level(CONFIG_DISPLAY_PIN_BL, 0));
@@ -181,7 +181,8 @@ static void esp_lcd_init(void* _ignored)
 
     ESP_ERROR_CHECK(esp_lcd_new_panel_st7789(io_handle, &panel_config, &ph));
 
-#if CONFIG_DISPLAY_PIN_BL != -1 && !defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)
+#if CONFIG_DISPLAY_PIN_BL != -1 && !defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)                                          \
+    && !defined(CONFIG_BOARD_TYPE_M5_STICKC_PLUS_2)
     ESP_ERROR_CHECK(gpio_set_level(CONFIG_DISPLAY_PIN_BL, 1));
 #endif
 

--- a/main/power/m5stickcplus2.inc
+++ b/main/power/m5stickcplus2.inc
@@ -1,12 +1,44 @@
-// M5StickCPlus implementation - uses IP5303 Power PMU
+// M5StickC Plus 2 implementation - uses IP5303 Power PMU
 //
 #include <driver/gpio.h>
+#include <driver/ledc.h>
 #include <esp_adc/adc_oneshot.h>
 
 #define POWER_HOLD_GPIO 4
 #define BATTERY_ADC_CHANNEL ADC_CHANNEL_2
 
+#define LCD_BL_LEDC_TIMER LEDC_TIMER_3
+#define LCD_BL_LEDC_MODE LEDC_HIGH_SPEED_MODE
+#define LCD_BL_LEDC_CHANNEL LEDC_CHANNEL_7
+#define LCD_BL_LEDC_DUTY_RES LEDC_TIMER_9_BIT
+#define LCD_BL_LEDC_DUTY_BITS 9
+#define LCD_BL_LEDC_FREQUENCY 256
+#define LCD_BL_LEDC_OFFSET 40
+
 static adc_oneshot_unit_handle_t adc1_handle = NULL;
+
+static esp_err_t brightness_init(void)
+{
+    gpio_reset_pin(CONFIG_DISPLAY_PIN_BL);
+    gpio_set_direction(CONFIG_DISPLAY_PIN_BL, GPIO_MODE_OUTPUT);
+
+    ledc_timer_config_t ledc_timer = { .speed_mode = LCD_BL_LEDC_MODE,
+        .timer_num = LCD_BL_LEDC_TIMER,
+        .duty_resolution = LCD_BL_LEDC_DUTY_RES,
+        .freq_hz = LCD_BL_LEDC_FREQUENCY,
+        .clk_cfg = LEDC_AUTO_CLK };
+    ESP_ERROR_CHECK(ledc_timer_config(&ledc_timer));
+
+    ledc_channel_config_t ledc_channel = { .speed_mode = LCD_BL_LEDC_MODE,
+        .channel = LCD_BL_LEDC_CHANNEL,
+        .timer_sel = LCD_BL_LEDC_TIMER,
+        .intr_type = LEDC_INTR_DISABLE,
+        .gpio_num = CONFIG_DISPLAY_PIN_BL,
+        .duty = 0,
+        .hpoint = 0 };
+    ESP_ERROR_CHECK(ledc_channel_config(&ledc_channel));
+    return ESP_OK;
+}
 
 esp_err_t power_init(void)
 {
@@ -14,6 +46,8 @@ esp_err_t power_init(void)
     gpio_reset_pin(POWER_HOLD_GPIO);
     gpio_set_direction(POWER_HOLD_GPIO, GPIO_MODE_OUTPUT);
     gpio_set_level(POWER_HOLD_GPIO, 1);
+
+    ESP_ERROR_CHECK(brightness_init());
 
     // Initialise the ADC to measure battery level
     //-------------ADC1 Init---------------//
@@ -42,8 +76,35 @@ esp_err_t power_shutdown(void)
 esp_err_t power_screen_on(void) { return ESP_OK; }
 esp_err_t power_screen_off(void) { return ESP_OK; }
 
-esp_err_t power_backlight_on(const uint8_t brightness) { return ESP_OK; }
-esp_err_t power_backlight_off(void) { return ESP_OK; }
+esp_err_t power_backlight_on(uint8_t brightness)
+{
+    if (brightness < BACKLIGHT_MIN) {
+        brightness = BACKLIGHT_MIN;
+    } else if (brightness > BACKLIGHT_MAX) {
+        brightness = BACKLIGHT_MAX;
+    }
+
+    const uint32_t scaled_brightness
+        = 1 + ((brightness - BACKLIGHT_MIN) * 254) / (BACKLIGHT_MAX - BACKLIGHT_MIN);
+    uint_fast16_t offset = LCD_BL_LEDC_OFFSET;
+    if (offset) {
+        offset = offset * 259 >> 8;
+    }
+    uint32_t duty = scaled_brightness * (257 - offset);
+    duty += offset * 255;
+    duty += 1 << (15 - LCD_BL_LEDC_DUTY_BITS);
+    duty >>= 16 - LCD_BL_LEDC_DUTY_BITS;
+
+    ESP_ERROR_CHECK(ledc_set_duty(LCD_BL_LEDC_MODE, LCD_BL_LEDC_CHANNEL, duty));
+    ESP_ERROR_CHECK(ledc_update_duty(LCD_BL_LEDC_MODE, LCD_BL_LEDC_CHANNEL));
+    return ESP_OK;
+}
+esp_err_t power_backlight_off(void)
+{
+    ESP_ERROR_CHECK(ledc_set_duty(LCD_BL_LEDC_MODE, LCD_BL_LEDC_CHANNEL, 0));
+    ESP_ERROR_CHECK(ledc_update_duty(LCD_BL_LEDC_MODE, LCD_BL_LEDC_CHANNEL));
+    return ESP_OK;
+}
 
 esp_err_t power_camera_on(void) { return ESP_OK; }
 esp_err_t power_camera_off(void) { return ESP_OK; }

--- a/main/process/dashboard.c
+++ b/main/process/dashboard.c
@@ -1703,7 +1703,8 @@ static void handle_view_otps(void)
 
 // NOTE: Only boards listed here have brightness controls
 #if defined(CONFIG_BOARD_TYPE_JADE_V1_1) || defined(CONFIG_BOARD_TYPE_JADE_V2_ANY)                                     \
-    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)
+    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)                            \
+    || defined(CONFIG_BOARD_TYPE_M5_STICKC_PLUS_2)
 static void handle_screen_brightness(void)
 {
     static const char* LABELS[] = { "Min(1)", "Low(2)", "Medium(3)", "High(4)", "Max(5)" };
@@ -2290,7 +2291,8 @@ static void handle_settings(const bool startup_menu)
 
 // NOTE: Only boards listed here have brightness controls
 #if defined(CONFIG_BOARD_TYPE_JADE_V1_1) || defined(CONFIG_BOARD_TYPE_JADE_V2_ANY)                                     \
-    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)
+    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2) || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)                            \
+    || defined(CONFIG_BOARD_TYPE_M5_STICKC_PLUS_2)
         case BTN_SETTINGS_DISPLAY_BRIGHTNESS:
             handle_screen_brightness();
             break;

--- a/main/ui/dashboard.c
+++ b/main/ui/dashboard.c
@@ -395,7 +395,7 @@ gui_activity_t* make_display_settings_activity(void)
     // NOTE: Only boards listed here have brightness controls
     // NOTE: Jade v1.1's do not support Flip Orientation because of issues with screen offsets
 #if defined(CONFIG_BOARD_TYPE_JADE_V2_ANY) || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2)                                 \
-    || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY)
+    || defined(CONFIG_BOARD_TYPE_TTGO_TDISPLAY) || defined(CONFIG_BOARD_TYPE_M5_STICKC_PLUS_2)
     btn_data_t menubtns[]
         = { { .txt = "Display Brightness", .font = GUI_DEFAULT_FONT, .ev_id = BTN_SETTINGS_DISPLAY_BRIGHTNESS },
               { .txt = "Flip Orientation", .font = GUI_DEFAULT_FONT, .ev_id = BTN_SETTINGS_DISPLAY_ORIENTATION },


### PR DESCRIPTION

https://github.com/user-attachments/assets/37f657b8-cda7-437a-9b9f-7532e5c2a30f

## Summary

Adds backlight brightness control support for the M5StickC Plus2.

This follows the same integration approach used for the TTGO T-Display brightness control: the dashboard exposes the existing display brightness setting for this board, while the board-specific power implementation owns the actual backlight PWM handling.

## Implementation

The M5StickC Plus2 uses different backlight PWM parameters from the TTGO T-Display. This implementation uses the M5StickC Plus2 backlight configuration from M5GFX/LovyanGFX:

- Backlight GPIO: `GPIO27`
- LEDC channel: `7`
- PWM frequency: `256 Hz`
- PWM offset: `40`
- 9-bit LEDC duty resolution

The Jade brightness levels are mapped to the same 1-5 brightness range used by the existing display brightness setting, then converted to the M5GFX-style PWM duty calculation.

The changes are intentionally scoped to the M5StickC Plus2 path and should not affect other boards.

## Testing

Tested on M5StickC Plus2 hardware:

- Display brightness menu is available
- Brightness can be increased and decreased across all levels
- Lowest brightness remains visible and does not turn the display off
- Button navigation direction remains unchanged for M5StickC Plus2
- Build succeeds for M5StickC Plus2