### PR TITLE
input: release touch handles before deleting the i2c bus

### DIFF
--- a/main/input/touchscreen.inc
+++ b/main/input/touchscreen.inc
@@ -91,6 +91,9 @@ static void touchscreen_task(void* ignored)
         }
         vTaskDelay(20 / portTICK_PERIOD_MS);
     }
+    // Since IDF 5.5 the i2c bus cannot be deleted while devices are still attached
+    ESP_ERROR_CHECK(esp_lcd_touch_del(ret_touch));
+    ESP_ERROR_CHECK(esp_lcd_panel_io_del(tp_io_handle));
     ESP_ERROR_CHECK(_i2c_deinit(touch_i2c_handle));
     shutdown_finished = true;
     vTaskDelete(NULL);


### PR DESCRIPTION
**Description**

This PR fixes the boot hang and camera freezes on the **Waveshare S3 Touch LCD 2** reported in #306, caused by an undocumented breaking change in ESP-IDF 5.5. Fixes #306.

**Root Cause**

- The regression bisects to a single commit: `d931d543` (esp-idf: update to v5.5.4).
- Since IDF v5.5.0 (espressif/esp-idf@e73d78ba), `i2c_del_master_bus()` refuses to delete a bus that still has devices attached and returns `ESP_ERR_INVALID_STATE`. Under v5.4 it destroyed the bus unconditionally.
- The touchscreen task registers a panel IO device on its i2c bus (`esp_lcd_new_panel_io_i2c()`, `touchscreen.inc:57`) but never releases it, so the first `touchscreen_deinit()` fails at `ESP_ERROR_CHECK(_i2c_deinit(...))` (`touchscreen.inc:94`) and aborts.
- This board panics with `CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT=y`, so it halts frozen on whatever is on screen.
- The only callers of `touchscreen_deinit()/init()` are `jade_camera_init()`/`jade_camera_stop()` (`camera.c:323-337`), which explains all three symptoms: boot entropy (splash), scanner stuck at "Initializing...", and the freeze when leaving the camera.

**Changes**

**`main/input/touchscreen.inc`**

- **Fix:** Release the touch handle (`esp_lcd_touch_del`) and the panel IO device (`esp_lcd_panel_io_del`, which removes it from the bus) before deleting the i2c bus.
- **Result:** The deinit/init cycle works again under IDF 5.5.4 for **all** touchscreen boards, including M5CoreS3, where the restart around the camera is load-bearing (camera and touch share i2c pins).
- **Bonus:** Also fixes a heap leak present under IDF 5.4, where both handles leaked on every camera start/stop cycle.

**Testing**

- Tested on real hardware (Waveshare S3 Touch LCD 2): boot passes the splash, the QR scanner opens and scans, exiting and re-opening the camera works, and touch keeps working afterwards.

**Motivation**

Restores basic usability for touchscreen DIY boards after the IDF 5.5.4 update with the smallest possible diff (3 lines) at the root cause, instead of board-specific workarounds.
