### PR TITLE
Shorten Home screen title when needed

### DIFF
--- a/main/gui.c
+++ b/main/gui.c
@@ -150,7 +150,8 @@ static void make_status_bar(void)
 #if HOME_SCREEN_DEEP_STATUS_BAR
     // Make an hsplit for the logo on the left, and info on the right
     gui_view_node_t* hsplit;
-    gui_make_hsplit(&hsplit, GUI_SPLIT_RELATIVE, 2, 65, 35);
+    gui_make_hsplit(&hsplit, GUI_SPLIT_RELATIVE, 2, 100 - HOME_SCREEN_STATUS_BAR_TITLE_WIDTH_PERCENT,
+        HOME_SCREEN_STATUS_BAR_TITLE_WIDTH_PERCENT);
     gui_set_padding(hsplit, GUI_MARGIN_ALL_DIFFERENT, 0, 2, 0, 2);
     gui_set_parent(hsplit, status_bar.root);
 
@@ -175,7 +176,7 @@ static void make_status_bar(void)
     name_alignment = GUI_ALIGN_RIGHT;
 #else
     // Make an hsplit for the icon, name, and status icons
-    gui_make_hsplit(&status_parent, GUI_SPLIT_RELATIVE, 5, 10, 57, 8, 8, 17);
+    gui_make_hsplit(&status_parent, GUI_SPLIT_RELATIVE, 5, 10, HOME_SCREEN_STATUS_BAR_TITLE_WIDTH_PERCENT, 8, 8, 17);
     gui_set_padding(status_parent, GUI_MARGIN_ALL_DIFFERENT, 3, 0, 0, 4);
     gui_set_parent(status_parent, status_bar.root);
 

--- a/main/gui.h
+++ b/main/gui.h
@@ -43,6 +43,7 @@ extern uint8_t GUI_DEFAULT_FONT;
 
 // Whether to use a deep status bar on the home screen, better suited to larger displays
 #define HOME_SCREEN_DEEP_STATUS_BAR (CONFIG_DISPLAY_HEIGHT >= 170)
+#define HOME_SCREEN_STATUS_BAR_TITLE_WIDTH_PERCENT (HOME_SCREEN_DEEP_STATUS_BAR ? 35 : 57)
 
 // Fill all the remaining space in an {h,v}split
 #define GUI_SPLIT_FILL_REMAINING 0xFF

--- a/main/ui/dashboard.c
+++ b/main/ui/dashboard.c
@@ -1,4 +1,6 @@
 #ifndef AMALGAMATED_BUILD
+#include <string.h>
+
 #include "../button_events.h"
 #include "../display.h"
 #include "../jade_assert.h"
@@ -47,6 +49,21 @@ static gui_view_node_t* make_home_screen_panel_item(const color_t color, home_me
     return item;
 }
 
+static const char* get_home_screen_title(const char* device_name)
+{
+    // Match the status-bar title column width from make_status_bar().
+    const int title_width = (CONFIG_DISPLAY_WIDTH * HOME_SCREEN_STATUS_BAR_TITLE_WIDTH_PERCENT) / 100;
+
+    display_set_font(GUI_TITLE_FONT);
+    if (display_get_string_width(device_name) <= title_width
+        || strncmp(device_name, "Jade ", strlen("Jade ")) != 0) {
+        return device_name;
+    }
+
+    // Remove "Jade " prefix to allow the device ID to be shown.
+    return device_name + strlen("Jade ");
+}
+
 gui_activity_t* make_home_screen_activity(const char* device_name, const char* firmware_version,
     home_menu_entry_t* selected_entry, home_menu_entry_t* next_entry, gui_view_node_t** status_light,
     gui_view_node_t** status_text, gui_view_node_t** label)
@@ -62,7 +79,7 @@ gui_activity_t* make_home_screen_activity(const char* device_name, const char* f
     // NOTE: The home screen is created as an 'unmanaged' activity as
     // its lifetime is same as that of the entire application
     gui_activity_t* act = NULL;
-    gui_make_activity_ex(&act, true, device_name, false);
+    gui_make_activity_ex(&act, true, get_home_screen_title(device_name), false);
     JADE_ASSERT(act);
 
     gui_view_node_t* node;


### PR DESCRIPTION
Note: opening this now so it is ready for review after the 1.0.41 release, as discussed in #274.

## Description
The Home status bar title can be clipped on displays where the full `Jade <fingerprint>` device name does not fit.

This keeps the full `Jade <fingerprint>` title when it fits. If it would be clipped, the Home screen falls back to showing only the fingerprint. The full device name remains unchanged elsewhere.

## Approach
- Measure the Home title with `GUI_TITLE_FONT`.
- Compare it against the status-bar title column width.
- Strip only the `Jade ` prefix when the full title would not fit.
- Keep the change scoped to the Home activity title.

## Testing
- Tested on Waveshare S3 Touch LCD2: the Home title falls back to the fingerprint-only title as intended.
- `git diff --check`