### PR TITLE
Fix touch navbar after display orientation flip

### DIFF
--- a/main/display.c
+++ b/main/display.c
@@ -185,8 +185,7 @@ void display_fill_rect(int x, int y, int w, int h, color_t color)
         || ((y - CONFIG_DISPLAY_OFFSET_Y) + h > CONFIG_DISPLAY_HEIGHT)) {
         JADE_LOGE(
             "display_fill_rect called with bad params (ignored) x %d y %d w %d h %d color %u\n", x, y, w, h, color);
-#if !defined(CONFIG_BOARD_TYPE_M5_CORES3) && !defined(CONFIG_BOARD_TYPE_TTGO_TWATCHS3)                                 \
-    && !defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2)
+#if !DISPLAY_HAS_TOUCH_NAVBAR
         return;
 #endif
     }
@@ -230,41 +229,18 @@ static void display_clear(void)
         CONFIG_DISPLAY_OFFSET_X, CONFIG_DISPLAY_OFFSET_Y, CONFIG_DISPLAY_WIDTH, CONFIG_DISPLAY_HEIGHT, TFT_BLACK);
 }
 
-void display_init(TaskHandle_t* gui_h)
-{
-    JADE_LOGI("display/screen init");
-    JADE_ASSERT(gui_h);
-#ifdef CONFIG_LIBJADE
-    if (*gui_h) {
-        return; // Already initialized
-    }
-#endif
-    JADE_ASSERT(!*gui_h);
-
-    JADE_ASSERT(power_screen_on() == ESP_OK);
-    vTaskDelay(100 / portTICK_PERIOD_MS);
-
-#if defined(CONFIG_ETH_USE_OPENETH)
-#if defined(CONFIG_HAS_CAMERA)
-    qemu_display_init();
-#endif
-#else
-    JADE_ASSERT(gui_h);
-    display_hw_init(gui_h);
-
-#if defined(CONFIG_BOARD_TYPE_TTGO_TWATCHS3) || defined(CONFIG_BOARD_TYPE_M5_CORES3)                                   \
-    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2)
-#define TOUCH_BUTTON_AREA 40
+#if DISPLAY_HAS_TOUCH_NAVBAR
 #define TOUCH_BUTTON_MARGIN 5
 #define TOUCH_BUTTON_WIDTH 40
-    /* The TwatchS3 and core s3 don't have buttons that can be used (just power and
-       reset)
-       but it has a touch panel, we use the bottom 40 pixels worth of height
-       to display 3 buttons (prev, OK, next), we handle this here rather than
-       in display_hw because we want to draw text inside the virtual buttons */
-
-    vTaskDelay(50 / portTICK_PERIOD_MS);
-
+/* The TwatchS3 and core s3 don't have buttons that can be used (just power and
+   reset)
+   but it has a touch panel, we use the area below the main display
+   to display 3 buttons (prev, OK, next), we handle this here rather than
+   in display_hw because we want to draw text inside the virtual buttons.
+   Called at startup and again whenever the display orientation is flipped,
+   as flipping remaps the panel and the navbar must be redrawn in place. */
+void display_touch_navbar_redraw(void)
+{
     /* blank the bottom of the display with black */
     uint16_t line[CONFIG_DISPLAY_WIDTH] = { TFT_BLACK };
     for (int16_t i = 0; i < TOUCH_BUTTON_AREA; ++i) {
@@ -287,7 +263,34 @@ void display_init(TaskHandle_t* gui_h)
     disp_win_virtual_buttons.x2 = (CONFIG_DISPLAY_WIDTH - TOUCH_BUTTON_MARGIN) + CONFIG_DISPLAY_OFFSET_X;
     display_print_in_area("I", CENTER, CENTER, disp_win_virtual_buttons, 0);
     display_set_font(DEFAULT_FONT);
+}
+#endif
 
+void display_init(TaskHandle_t* gui_h)
+{
+    JADE_LOGI("display/screen init");
+    JADE_ASSERT(gui_h);
+#ifdef CONFIG_LIBJADE
+    if (*gui_h) {
+        return; // Already initialized
+    }
+#endif
+    JADE_ASSERT(!*gui_h);
+
+    JADE_ASSERT(power_screen_on() == ESP_OK);
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+
+#if defined(CONFIG_ETH_USE_OPENETH)
+#if defined(CONFIG_HAS_CAMERA)
+    qemu_display_init();
+#endif
+#else
+    JADE_ASSERT(gui_h);
+    display_hw_init(gui_h);
+
+#if DISPLAY_HAS_TOUCH_NAVBAR
+    vTaskDelay(50 / portTICK_PERIOD_MS);
+    display_touch_navbar_redraw();
     vTaskDelay(50 / portTICK_PERIOD_MS);
 #endif
 #endif

--- a/main/display.h
+++ b/main/display.h
@@ -91,6 +91,23 @@ extern const color_t TFT_PINK;
 
 void display_init(TaskHandle_t* gui_h);
 bool display_flip_orientation(bool flipped_orientation);
+
+#if defined(CONFIG_BOARD_TYPE_TTGO_TWATCHS3) || defined(CONFIG_BOARD_TYPE_M5_CORES3)                                   \
+    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2)
+#define DISPLAY_HAS_TOUCH_NAVBAR 1
+#else
+#define DISPLAY_HAS_TOUCH_NAVBAR 0
+#endif
+
+// Height in pixels of the touch area reserved below the main display for the
+// virtual navigation buttons (or the fixed capacitive strip on the M5 Core2)
+#define TOUCH_BUTTON_AREA 40
+
+#if DISPLAY_HAS_TOUCH_NAVBAR
+void display_touch_navbar_redraw(void);
+#else
+static inline void display_touch_navbar_redraw(void) {}
+#endif
 Icon* get_icon(const uint8_t* start, const uint8_t* end);
 Picture* get_picture(const uint8_t* start, const uint8_t* end);
 void display_picture(const Picture* imgbuf, int x, int y, dispWin_t area);

--- a/main/display_hw.c
+++ b/main/display_hw.c
@@ -284,9 +284,7 @@ inline void display_hw_draw_bitmap(int x, int y, int w, int h, const uint16_t* c
     JADE_ASSERT(color_data);
     const int calculatedx = x - CONFIG_DISPLAY_OFFSET_X;
     const int calculatedy = y - CONFIG_DISPLAY_OFFSET_Y;
-#if (defined(CONFIG_BOARD_TYPE_M5_CORES3) || defined(CONFIG_BOARD_TYPE_TTGO_TWATCHS3)                                  \
-    || defined(CONFIG_BOARD_TYPE_WS_TOUCH_LCD2))                                                                       \
-    && defined(CONFIG_DISPLAY_FULL_FRAME_BUFFER)
+#if DISPLAY_HAS_TOUCH_NAVBAR && defined(CONFIG_DISPLAY_FULL_FRAME_BUFFER)
     /* this is required for the virtual buttons */
     if (calculatedy >= CONFIG_DISPLAY_HEIGHT) {
         ESP_ERROR_CHECK(

--- a/main/gui.c
+++ b/main/gui.c
@@ -263,7 +263,12 @@ bool gui_get_flipped_orientation(void) { return gui_orientation_flipped; }
 
 bool gui_set_flipped_orientation(const bool flipped_orientation)
 {
-    gui_orientation_flipped = display_flip_orientation(flipped_orientation);
+    const bool new_orientation = display_flip_orientation(flipped_orientation);
+    if (gui_orientation_flipped != new_orientation) {
+        gui_orientation_flipped = new_orientation;
+        // Redraw the virtual navbar buttons (if any) at their new position
+        display_touch_navbar_redraw();
+    }
     return gui_orientation_flipped;
 }
 

--- a/main/input/touchscreen.inc
+++ b/main/input/touchscreen.inc
@@ -29,9 +29,11 @@ static void touchscreen_task(void* ignored)
 {
     esp_lcd_touch_handle_t ret_touch = NULL;
     // FIXME: check mirror flags?
+    // NOTE: the touch panel extends below the main display over the navigation button
+    // area - y_max must cover it, as it is used when mirroring coordinates on flip
     const esp_lcd_touch_config_t tp_cfg = {
         .x_max = CONFIG_DISPLAY_WIDTH + CONFIG_DISPLAY_OFFSET_X,
-        .y_max = CONFIG_DISPLAY_HEIGHT + CONFIG_DISPLAY_OFFSET_Y,
+        .y_max = CONFIG_DISPLAY_HEIGHT + CONFIG_DISPLAY_OFFSET_Y + TOUCH_BUTTON_AREA,
         .rst_gpio_num = GPIO_NUM_NC,
         .int_gpio_num = GPIO_NUM_NC,
         .levels = {
@@ -65,17 +67,32 @@ static void touchscreen_task(void* ignored)
     uint16_t touch_strength[1];
     uint8_t touch_cnt = 10;
 
+#if DISPLAY_HAS_TOUCH_NAVBAR
+    // Track the display orientation and mirror the touch Y coordinate to match, so the
+    // virtual navbar button band keeps working when the display is flipped. Leave X
+    // unchanged so the left/right navigation actions stay on the same physical sides.
+    // Not on the M5 Core2, where the buttons are silk-screened on a fixed strip below
+    // the display.
+    bool touch_mirrored = false;
+#endif
+
     // FIXME: don't allow multiple touches within 300 ms?
-    // FIXME: this doesn't currently work with Display -> Flip Orientation feature
-    // but it could by changing the touch_y[0] > 200 logic with < 40 and inverting prev with next and viceversa
     while (!shutdown_requested) {
+#if DISPLAY_HAS_TOUCH_NAVBAR
+        const bool flipped = gui_get_flipped_orientation();
+        if (touch_mirrored != flipped) {
+            ESP_ERROR_CHECK(esp_lcd_touch_set_mirror_x(ret_touch, false));
+            ESP_ERROR_CHECK(esp_lcd_touch_set_mirror_y(ret_touch, flipped));
+            touch_mirrored = flipped;
+        }
+#endif
         if (esp_lcd_touch_read_data(ret_touch) == ESP_OK) {
             bool touchpad_pressed
                 = esp_lcd_touch_get_coordinates(ret_touch, touch_x, touch_y, touch_strength, &touch_cnt, 1);
             if (touchpad_pressed) {
                 const uint16_t first_third_end = CONFIG_DISPLAY_WIDTH / 3;
                 const uint16_t middle_thirds_end = (CONFIG_DISPLAY_WIDTH * 2) / 3;
-                if (touch_y[0] > 200) {
+                if (touch_y[0] > CONFIG_DISPLAY_HEIGHT + CONFIG_DISPLAY_OFFSET_Y) {
                     if (touch_x[0] <= first_third_end) {
                         gui_prev();
                     } else if (touch_x[0] > first_third_end && touch_x[0] < middle_thirds_end) {

--- a/main/input/touchscreen.inc
+++ b/main/input/touchscreen.inc
@@ -29,9 +29,11 @@ static void touchscreen_task(void* ignored)
 {
     esp_lcd_touch_handle_t ret_touch = NULL;
     // FIXME: check mirror flags?
+    // NOTE: the touch panel extends below the main display over the navigation button
+    // area - y_max must cover it, as it is used when mirroring coordinates on flip
     const esp_lcd_touch_config_t tp_cfg = {
         .x_max = CONFIG_DISPLAY_WIDTH + CONFIG_DISPLAY_OFFSET_X,
-        .y_max = CONFIG_DISPLAY_HEIGHT + CONFIG_DISPLAY_OFFSET_Y,
+        .y_max = CONFIG_DISPLAY_HEIGHT + TOUCH_BUTTON_AREA,
         .rst_gpio_num = GPIO_NUM_NC,
         .int_gpio_num = GPIO_NUM_NC,
         .levels = {
@@ -65,17 +67,32 @@ static void touchscreen_task(void* ignored)
     uint16_t touch_strength[1];
     uint8_t touch_cnt = 10;
 
+#if DISPLAY_HAS_TOUCH_NAVBAR
+    // Track the display orientation and mirror the touch Y coordinate to match, so the
+    // virtual navbar button band keeps working when the display is flipped. Leave X
+    // unchanged so the left/right navigation actions stay on the same physical sides.
+    // Not on the M5 Core2, where the buttons are silk-screened on a fixed strip below
+    // the display.
+    bool touch_mirrored = false;
+#endif
+
     // FIXME: don't allow multiple touches within 300 ms?
-    // FIXME: this doesn't currently work with Display -> Flip Orientation feature
-    // but it could by changing the touch_y[0] > 200 logic with < 40 and inverting prev with next and viceversa
     while (!shutdown_requested) {
+#if DISPLAY_HAS_TOUCH_NAVBAR
+        const bool flipped = gui_get_flipped_orientation();
+        if (touch_mirrored != flipped) {
+            ESP_ERROR_CHECK(esp_lcd_touch_set_mirror_x(ret_touch, false));
+            ESP_ERROR_CHECK(esp_lcd_touch_set_mirror_y(ret_touch, flipped));
+            touch_mirrored = flipped;
+        }
+#endif
         if (esp_lcd_touch_read_data(ret_touch) == ESP_OK) {
             bool touchpad_pressed
                 = esp_lcd_touch_get_coordinates(ret_touch, touch_x, touch_y, touch_strength, &touch_cnt, 1);
             if (touchpad_pressed) {
                 const uint16_t first_third_end = CONFIG_DISPLAY_WIDTH / 3;
                 const uint16_t middle_thirds_end = (CONFIG_DISPLAY_WIDTH * 2) / 3;
-                if (touch_y[0] > 200) {
+                if (touch_y[0] > CONFIG_DISPLAY_HEIGHT) {
                     if (touch_x[0] <= first_third_end) {
                         gui_prev();
                     } else if (touch_x[0] > first_third_end && touch_x[0] < middle_thirds_end) {


### PR DESCRIPTION
## Summary

This fixes the touch navigation bar behavior when the display orientation is flipped on boards that use the Jade-drawn virtual navbar.

Previously, flipping the display orientation could leave the virtual navbar out of sync with the touch coordinates: the navbar needed to be redrawn in the new orientation, and touches in the navbar band needed to follow the flipped display coordinates.

This change:

- extracts the virtual navbar drawing into a reusable redraw helper
- redraws the virtual navbar after the display orientation changes
- adds a shared `DISPLAY_HAS_TOUCH_NAVBAR` guard for boards with the Jade-drawn navbar
- moves the touch navbar height into a shared `TOUCH_BUTTON_AREA` constant
- extends the touch Y range to include the navbar area
- mirrors the touch Y coordinate when the display is flipped
- keeps the touch X coordinate unchanged, so the physical left/right navigation sides remain consistent

The navbar redraw and the touch mirroring apply to the boards that use the Jade-drawn touch navbar:

- M5 CoreS3
- TTGO T-Watch S3
- Waveshare S3 Touch LCD2

M5 Core2 is excluded from those two: its buttons are fixed capacitive hot zones below the display, not the Jade-drawn virtual navbar, so they must not follow the flip.

The two touch changes (`y_max` and the navbar band threshold) do apply to all four touchscreen boards, since they describe the panel rather than the navbar. Replacing the hardcoded `touch_y[0] > 200` with the board display height also fixes a pre-existing bug on the M5 Core2, where taps on the bottom 40 pixels of the GUI area triggered navigation. Neither expression includes `CONFIG_DISPLAY_OFFSET_Y`: that is the ST7789 GRAM gap fed to `esp_lcd_panel_set_gap()`, a display-side value the touch controller never sees.

## Testing

Tested on Waveshare S3 Touch LCD2:

- default orientation: prev / OK / next work as expected
- flipped orientation: navbar is redrawn correctly
- flipped orientation: prev / OK / next remain on the expected physical sides
- entered and exited the QR scanner flow with flipped orientation enabled

I do not have M5 CoreS3 or TTGO T-Watch S3 hardware to test directly. All four touchscreen targets (`m5cores3`, `m5core2`, `ttgo_twatchs3`, `waveshares3_touch_lcd2`) build clean against ESP-IDF v5.5.4.

Thanks to @CaTeIM for helping investigate the touchscreen/navbar behavior and the orientation mirroring approach.


